### PR TITLE
fix: Alec review feedback (dependsOn validation, apply safety)

### DIFF
--- a/scripts/register.sh
+++ b/scripts/register.sh
@@ -63,14 +63,10 @@ if [[ "$MODE" != "dryRun" && "$MODE" != "apply" ]]; then
   exit 2
 fi
 
-# --- Auto-detect repo if not specified ---
-if [[ -z "$REPO" && "$MODE" == "apply" ]]; then
-  REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)
-  if [[ -z "$REPO" ]]; then
-    echo "[ERROR] Could not detect repository. Use --repo owner/repo" >&2
-    exit 2
-  fi
-  echo "[INFO] Auto-detected repo: $REPO" >&2
+# --- Repo validation for apply ---
+if [[ "$MODE" == "apply" && -z "$REPO" ]]; then
+  echo "[ERROR] --repo is required for apply mode (safety: explicit target only)" >&2
+  exit 2
 fi
 
 # --- Pre-flight checks ---


### PR DESCRIPTION
## Alec Review Feedback

### Fixed
1. **dependsOn reference validation**: `dependsOn` の参照先が issues[] に存在しない場合エラー
2. **apply safety**: `--repo` を apply モードで必須に（auto-detect 削除）

### Already OK (confirmed)
3. **idempotency**: `--state all` で closed 含む検索済み、match 時は skip + ログ
4. **gh-wrapper retry**: 5xx + rate limit のみリトライ、4xx (401/403/404/422) は即失敗
5. **exit codes**: validate=1, fatal=2, partial=1（SKILL.md に記載済み）

### E2E Plan
テスト用repo で: dryRun → apply → 再実行(冪等) → 途中失敗 → 再開

Refs review comments